### PR TITLE
Split by chrom

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -10,4 +10,9 @@ workflows:
      primaryDescriptorPath: /imputation_server_results.wdl
      testParameterFiles:
          - /imputation_server_results.json
+   - name: chrom_split
+     subclass: WDL
+     primaryDescriptorPath: /split_by_chrom.wdl
+     testParameterFiles:
+         - /split_by_chrom.json
          

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ The user must specify the following inputs:
 input | description
 --- | ---
 token | string with the authentication token (note the example in the JSON file is not a real token)
-hostname | URL for either the TOPMed or Michigan server
-refpanel | “topmed-r2” is the only option for TOPMed, but there are multiple options for Michigan
+hostname | URL for either the [TOPMed](https://imputation.biodatacatalyst.nhlbi.nih.gov/) or [Michigan](https://imputationserver.sph.umich.edu/) server
+refpanel | “topmed-r2” is the only option for TOPMed, but there are [multiple options](https://imputationbot.readthedocs.io/en/latest/reference-panels/) for Michigan
 population | “all” for TOPMed, multiple options for Michigan
-vcf_files | files to impute
+vcf_files | files to impute. if `multi_chrom_file` is `true`, only one file should be provided.
+multi_chrom_file | boolean, set to 'true' if `vcf_files` contains a single file with multiple chromosomes; `false` if `vcf_files` are already split by chromosome
 password | string that must also be supplied to the results workflow for download. Specifying the password during job submission means the user doesn’t have to rely on receiving the password by email.
 
 When VCF files are submitted to the imputation server, a job_id is

--- a/imputation_server_submit.wdl
+++ b/imputation_server_submit.wdl
@@ -74,9 +74,8 @@ task submit {
      command {
           mkdir ~/.imputationbot
           printf -- "-  hostname: %s\n   token: %s\n" ${hostname} ${token} > ~/.imputationbot/imputationbot.instances
-          echo "imputationbot impute --file ${sep=' ' vcf_files} --refpanel ${refpanel} --population ${population} --password ${password} > tmp"
-          #grep -o \'job.*\' tmp | sed "s/'//g" > job_id.txt
-          echo "123" > job_id.txt
+          imputationbot impute --file ${sep=' ' vcf_files} --refpanel ${refpanel} --population ${population} --password ${password} > tmp
+          grep -o \'job.*\' tmp | sed "s/'//g" > job_id.txt
      }
 
      output {

--- a/split_by_chrom.json
+++ b/split_by_chrom.json
@@ -1,0 +1,5 @@
+{
+    "chrom_split.vcf_files": [
+        "gs://fc-106cccfd-1201-4f53-aaa8-949630868fba/submissions/19266730-a01e-405e-93e5-37510b58db8e/plink2_bed2vcf/6dd6e074-318d-4917-9a9c-f34bdaf296db/call-results/hapmap3_r3_b37_Ilmn1M.vcf.gz"
+    ]
+}

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -25,6 +25,7 @@ task split_by_chrom {
      }
 
      command {
+          bcftools index ${vcf_file}
           bcftools query -f '%CHROM\n' ${vcf_file} | sort -u > chroms.txt
           while read -r c; do
                bcftools view --regions "$c" -Oz -o "chr$c.vcf.gz" ${vcf_file}

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -11,7 +11,6 @@ workflow chrom_split {
 
      output {
           Array[File] chrom_files = split_by_chrom.chrom_files
-          File chrom_list = split_by_chrom.chrom_list
      }
 
      meta {
@@ -28,7 +27,7 @@ task split_by_chrom {
      command {
           bcftools query -f '%CHROM\n' ${vcf_file} | sort -u > chroms.txt
           while read -r c; do
-               bcftools view --regions "$c" -Oz -o "chr$c.vcf.gz"
+               bcftools view --regions "$c" -Oz -o "chr$c.vcf.gz" ${vcf_file}
           done < chroms.txt
      }
 

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -6,7 +6,7 @@ workflow chrom_split {
      }
 
      call split_by_chrom {
-          input: vcf_file = vcf_files[1]
+          input: vcf_file = vcf_files[0]
      }
 
      output {

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -22,8 +22,9 @@ workflow chrom_split {
 task split_by_chrom {
      input {
           File vcf_file
-          String vcf_basename = basename(vcf_file)
      }
+
+     String vcf_basename = basename(vcf_file)
 
      command {
           bcftools index ${vcf_file}

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -1,0 +1,41 @@
+version 1.0
+
+workflow chrom_split {
+     input {
+          Array[File] vcf_files
+     }
+
+     call split_by_chrom {
+          input: vcf_file = vcf_files[1]
+     }
+
+     output {
+          Array[File] chrom_files = split_by_chrom.chrom_files
+     }
+
+     meta {
+          author: "Stephanie Gogarten"
+          email: "sdmorris@uw.edu"
+     }
+}
+
+task split_by_chrom {
+     input {
+          File vcf_file
+     }
+
+     command {
+          bcftools query -f '%CHROM\n' ${vcf_file} | sort -u > chroms.txt
+          while read -r c; do
+               bcftools view --regions "$c" -Oz -o "chr$c.vcf.gz"
+          done < chroms.txt
+     }
+
+     output {
+          Array[File] chrom_files = glob("*.vcf.gz")
+     }
+
+     runtime {
+        docker: "xbrianh/xsamtools:v0.5.2"
+    }
+}

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -38,6 +38,6 @@ task split_by_chrom {
      }
 
      runtime {
-        docker: "xbrianh/xsamtools:v0.5.2"
+        docker: "staphb/bcftools:1.16"
     }
 }

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -24,7 +24,7 @@ task split_by_chrom {
           File vcf_file
      }
 
-     String vcf_basename = basename(vcf_file)
+     String vcf_basename = basename(vcf_file, ".vcf.gz")
 
      command {
           bcftools index ${vcf_file}

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -22,13 +22,14 @@ workflow chrom_split {
 task split_by_chrom {
      input {
           File vcf_file
+          String vcf_basename = basename(vcf_file)
      }
 
      command {
           bcftools index ${vcf_file}
           bcftools query -f '%CHROM\n' ${vcf_file} | sort -u > chroms.txt
           while read -r c; do
-               bcftools view --regions "$c" -Oz -o "chr$c.vcf.gz" ${vcf_file}
+               bcftools view --regions "$c" -Oz -o ${vcf_basename}".$c.vcf.gz" ${vcf_file}
           done < chroms.txt
      }
 

--- a/split_by_chrom.wdl
+++ b/split_by_chrom.wdl
@@ -11,6 +11,7 @@ workflow chrom_split {
 
      output {
           Array[File] chrom_files = split_by_chrom.chrom_files
+          File chrom_list = split_by_chrom.chrom_list
      }
 
      meta {
@@ -33,6 +34,7 @@ task split_by_chrom {
 
      output {
           Array[File] chrom_files = glob("*.vcf.gz")
+          File chrom_list = "chroms.txt"
      }
 
      runtime {


### PR DESCRIPTION
The imputation server requires files split by chromosome. If the supplied file has multiple chromosomes; split first.